### PR TITLE
Fix: link del evento del Seminario Socrático #13 apuntaba a un evento anterior

### DIFF
--- a/content/2026-06-24-socratic-seminar-13.md
+++ b/content/2026-06-24-socratic-seminar-13.md
@@ -2,7 +2,7 @@
 title = "BitdevsBA Seminario Socratico #13"
 template = "post.html"
 [extra]
-meetup_id = "evt_rvk9RbqLFhRX27GH"
+meetup_url = "https://www.meetup.com/4opensource/events/315334663/?slug=4opensource&eventId=315334663"
 +++
 
 ### Cronograma

--- a/templates/post.html
+++ b/templates/post.html
@@ -4,10 +4,10 @@
         <h1 class="Post-title">{{ page.title }}</h1>
         <div class="Post-info">
             <span>{{ page.date }}</span>
-            {% if page.extra.meetup_id %}
+            {% if page.extra.meetup_url or page.extra.meetup_id %}
             <span>
                 <a
-                    href="{{ config.extra.meetup }}/{{ page.extra.meetup_id }}"
+                    href="{% if page.extra.meetup_url %}{{ page.extra.meetup_url }}{% else %}{{ config.extra.meetup }}/{{ page.extra.meetup_id }}{% endif %}"
                     target="_blank"
                     rel="noopener nofollow"
                 >


### PR DESCRIPTION
## Problema

En https://bitdevsba.org/socratic-seminar-13/ el enlace **"Link to Event"** apuntaba a un evento anterior (el Seminario Socrático #12 de abril).

La causa: `content/2026-06-24-socratic-seminar-13.md` reutilizaba el mismo `meetup_id` (`evt_rvk9RbqLFhRX27GH`) que el #12, y la plantilla construye el link como `https://evento.so/p/{meetup_id}`, por lo que terminaba enlazando al evento de abril.

## Solución

El evento correcto del #13 está en Meetup, no en evento.so, así que agregué soporte para un override de URL completa:

- `templates/post.html`: nuevo campo opcional `extra.meetup_url`. Si está presente, se usa la URL tal cual; si no, se mantiene el comportamiento anterior (`config.extra.meetup` + `meetup_id`). Retrocompatible con el resto de los seminarios.
- `content/2026-06-24-socratic-seminar-13.md`: ahora usa `meetup_url` apuntando al evento correcto:
  `https://www.meetup.com/4opensource/events/315334663/?slug=4opensource&eventId=315334663`